### PR TITLE
Make landing view-toggle focus ring keyboard-only

### DIFF
--- a/src/app/pages/landing/landing.css
+++ b/src/app/pages/landing/landing.css
@@ -211,7 +211,7 @@
   color: #e0e6f0;
 }
 
-.view-toggle:focus-within .view-toggle-rail {
+.view-toggle-input:focus-visible + .view-toggle-rail {
   border-color: #6db3f2;
   box-shadow: 0 0 0 2px rgba(109, 179, 242, 0.22);
 }


### PR DESCRIPTION
### Motivation
- Prevent the blue focus ring from appearing when the user clicks the landing page view-mode toggle while preserving an accessible focus indicator for keyboard users.

### Description
- Replace the parent `:focus-within` rule with an input-level `:focus-visible` rule in `src/app/pages/landing/landing.css` by changing `.view-toggle:focus-within .view-toggle-rail` to `.view-toggle-input:focus-visible + .view-toggle-rail`, keeping toggle behavior unchanged but making the focus ring keyboard-only.

### Testing
- Ran `pnpm -s biome check src/app/pages/landing/landing.css`, which reported the path was ignored so no checks were applied.
- Ran `pnpm -s build`, which completed successfully and produced the application bundle.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eccdc34640832bb0c6b1e1a6591365)