### PR TITLE
feat(post): add next-lesson navigation button

### DIFF
--- a/src/app/pages/post/post.html
+++ b/src/app/pages/post/post.html
@@ -57,6 +57,20 @@
 
   <article class="post-body" [innerHTML]="safeHtml()"></article>
 
+  <section class="lesson-nav">
+    @if (nextPost(); as nextPost) {
+      <a class="next-lesson-btn" [routerLink]="['/blog', nextPost.slug]">
+        下一课：{{ nextPost.title }}
+        <i class="ph ph-arrow-right" aria-hidden="true"></i>
+      </a>
+    } @else {
+      <a class="next-lesson-btn" routerLink="/blog">
+        已是最后一课，返回课程列表
+        <i class="ph ph-list" aria-hidden="true"></i>
+      </a>
+    }
+  </section>
+
   <section class="giscus-wrapper">
     <app-giscus-comments />
   </section>

--- a/src/app/pages/post/post.ts
+++ b/src/app/pages/post/post.ts
@@ -59,6 +59,20 @@ export class PostComponent implements OnDestroy {
     return POSTS.find(p => p.slug === s);
   });
 
+  readonly nextPost = computed(() => {
+    const current = this.post();
+    if (!current) {
+      return null;
+    }
+
+    const currentIndex = POSTS.findIndex(p => p.slug === current.slug);
+    if (currentIndex < 0 || currentIndex >= POSTS.length - 1) {
+      return null;
+    }
+
+    return POSTS[currentIndex + 1];
+  });
+
   private readonly processedContent = computed(() => {
     const p = this.post();
     return p ? buildContentWithToc(p.contentHtml) : { html: '', toc: [] as TocItem[] };

--- a/src/app/pages/post/styles/layout.css
+++ b/src/app/pages/post/styles/layout.css
@@ -174,6 +174,33 @@
   border-top: 1px solid var(--border-light);
 }
 
+.lesson-nav {
+  margin-top: 2.2rem;
+  display: flex;
+}
+
+.next-lesson-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.72rem 1rem;
+  border-radius: 0.72rem;
+  border: 1px solid color-mix(in srgb, var(--link-color) 36%, transparent);
+  background: color-mix(in srgb, var(--link-color) 10%, transparent);
+  color: var(--text-color);
+  font-family: var(--font-heading);
+  font-size: 0.95rem;
+  text-decoration: none;
+  transition: transform 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.next-lesson-btn:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--link-color) 16%, transparent);
+  border-color: color-mix(in srgb, var(--link-color) 50%, transparent);
+  text-decoration: none;
+}
+
 .not-found {
   text-align: center;
   padding: 3rem 0;


### PR DESCRIPTION
### Motivation
- Add a quick navigation from the end of each lesson to the next lesson to improve course flow and reduce manual navigation.

### Description
- Add a `nextPost` computed state in `src/app/pages/post/post.ts` that finds the next post by locating the current `slug` index in `POSTS` and returning the subsequent entry or `null` if none exists.
- Render a new lesson navigation block after the post content in `src/app/pages/post/post.html` that conditionally shows `下一课：{title}` linking to the next lesson or a fallback link back to `/blog` when at the last lesson.
- Add styling for `.lesson-nav` and `.next-lesson-btn` in `src/app/pages/post/styles/layout.css` to match the existing page design and provide hover effects.
- Edge cases are handled by returning `null` for `nextPost` when no next post exists so the fallback action is displayed.

### Testing
- Ran the site build with `pnpm run build`, which includes the prebuild content generation (`scripts/build-posts.mjs`) and the Angular build, and the command completed successfully.
- The build output included generated posts/redirects and a successful prerender and bundle generation, indicating the changes compile and produce the static output as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecd0706d80832b8504539b6fa2d71f)